### PR TITLE
Added solrnormalization pipeline demo

### DIFF
--- a/annotate/solrnormalization_pipeline_demo.ipynb
+++ b/annotate/solrnormalization_pipeline_demo.ipynb
@@ -20,36 +20,78 @@
       },
       "source": [
         "## What is this notebook about?\n",
-        "This notebook introduces the SolrNormalization component of the [impresso-pipelines](https://pypi.org/project/impresso-pipelines/) Python package. The broader goal of the impresso pipelines is to make the internal data processing workflows of the impresso project reusable and accessible to others. It allows external users—such as researchers, developers, or digital humanities practitioners—to apply the same processing steps we used on our historical newspaper collections to their own text collections.\n",
         "\n",
-        "The package is designed to minimize the coding effort required. By offering ready-to-use pipelines, users can adopt the impresso approach to document processing with minimal configuration. This ensures consistency, comparability, and transparency in how Solr-normalized data is prepared and evaluated.\n",
+        "This notebook introduces the SolrNormalization component of the\n",
+        "[impresso-pipelines](https://pypi.org/project/impresso-pipelines/) Python package. The\n",
+        "broader goal of the Impresso pipelines is to make the internal data processing workflows\n",
+        "of the Impresso webapp transparent, reusable and accessible to others. It allows\n",
+        "external users—such as researchers, developers, or digital humanities practitioners—to\n",
+        "apply the same processing steps we used on our historical newspaper collections to their\n",
+        "own text collections.\n",
         "\n",
-        "In this notebook, we focus on the [solrnormalization](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization) subpackage, which enables Solr-style tokenization and normalization using Lucene analyzers directly from Python. It supports language detection and applies language-specific analyzers for German and French.\n",
+        "By offering ready-to-use pipelines, users can adopt the Impresso approach to document\n",
+        "processing with minimal configuration. This ensures consistency, comparability, and\n",
+        "transparency in how our Solr-based Information Retrieval (IR) system splits texts into words\n",
+        "(also known as \"tokens\" in the NLP community) and normalizes these words for the search index.\n",
         "\n",
+        "In this notebook, we focus on the\n",
+        "[solrnormalization](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization)\n",
+        "subpackage, which offers Solr tokenization and normalization\n",
+        "analyzers directly from Python. It supports automatic language detection and applies\n",
+        "language-specific analyzers for all languages that the Impresso indexer treats in a\n",
+        "language-dependent way.\n",
         "\n",
         "## Why is this useful?\n",
         "\n",
-        "*   Text collections—especially historical or multilingual ones—often contain inconsistencies in spelling, formatting, and linguistic conventions across languages, time periods, and sources.\n",
-        "*   This pipeline provides a standardized, language-aware normalization process using Lucene analyzers, making it easier to apply consistent preprocessing across supported languages and prepare clean, comparable input for downstream models or analytical tools.\n",
-        "*   It also makes the normalization process more transparent by exposing the exact tokens produced after language-specific analyzers are applied.\n",
-        "\n",
+        "- European languages found in our Impresso collection are inflecting, meaning that the same word can appear in many\n",
+        "  different forms (e.g., \"introduce\", \"introduces\", \"introduced\", \"introducing\").\n",
+        "  Typical search engines reduce these forms to a base form (a process called stemming)\n",
+        "  that allows users to find all forms of a word with a single search term.\n",
+        "- Newspapers also use title casing and uppercasing, therefore search engines typically\n",
+        "  convert all text to lowercase before indexing.\n",
+        "- Stopwords (common words like \"the\", \"and\", \"is\") appear very frequently and are\n",
+        "  typically not searched for. As they would also need a lot of storage (e.g. in English,\n",
+        "  1/6th of all tokens is the word \"the\"), it is also resource-efficient to remove\n",
+        "  them from the index.\n",
+        "- Text collections—especially historical ones—often contain inconsistencies in spelling\n",
+        "  and linguistic conventions across time periods and sources, the use of special\n",
+        "  characters, diacritics, accessnts can vary over time. Ignoring diacritics and mapping\n",
+        "  non-ASCII characters to their ASCII equivalents (a process called ASCII folding) helps\n",
+        "  to ensure that searches are not affected by these variations.\n",
+        "- This pipeline provides a standardized, language-aware tokenization and normalization\n",
+        "  pipeline to simulate and understand the text transformations that happen when we index\n",
+        "  our texts, or when a user formulates a query. In order to find hits with a\n",
+        "  user-provided query, it is necessary to apply the exact same normalizations to the query as\n",
+        "  to the texts.\n",
+        "- Therefore, this pipeline helps to understand the text normalization process by\n",
+        "  exposing the exact tokens produced after language-specific analyzers and stopword\n",
+        "  lists have been applied.\n",
         "\n",
         "## How it works\n",
         "\n",
-        "*   **Init**: Load Lucene analyzers and stopword lists for supported languages (`de`, `fr`).\n",
-        "*   **Language Detection**: Automatically detect the language of the input text unless manually specified.\n",
-        "*   **Analyze**: Apply language-specific tokenization, lowercasing, stopword removal, ASCII folding, and stemming using Lucene filters.\n",
-        "*   **Output**: Return a list of normalized tokens along with the detected language.\n",
-        "*   **Extras**: Optionally pass a custom Lucene JAR directory or enable `__enter__/__exit__` context handling for cleanup.\n",
-        "\n",
+        "- **Init**: Load Lucene analyzers and stopword lists for all languages with\n",
+        "  language-specific stopwords and normalization. Additionally, load a generic text\n",
+        "  analzser for any other language.\n",
+        "- **Language Detection**: Automatically detect the language of the input text unless manually specified.\n",
+        "- **Analyze**: Apply language-specific tokenization, lowercasing, stopword removal,\n",
+        "  ASCII folding, and stemming using Solr components.\n",
+        "- **Output**: Return a list of normalized tokens along with the language information.\n",
         "\n",
         "## Technical background\n",
         "\n",
-        "- **Lucene Analyzers**: Java-based components that apply tokenization, lowercasing, stopword removal, ASCII folding, and light language-specific normalization in a configurable sequence.\n",
-        "- **CustomAnalyzer**: Lucene's builder interface allows fine-grained control over the filter and tokenizer pipeline for each supported language.\n",
-        "- **JPype Integration**: Bridges Python and Java, enabling direct access to Lucene's analysis pipeline from within Python code.\n",
-        "- **Language Detection**: Uses [`LangIdentPipeline`](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/langident) to automatically select the appropriate analyzer when the language is not specified manually.\n",
-        "- **Post-Processing**: Returns normalized tokens and the detected language; supports resource cleanup via context manager or destructor.\n"
+        "- **Solr Analyzers**: Java-based components that apply tokenization, lowercasing,\n",
+        "  stopword removal, ASCII folding, and language-specific stemming in a configurable\n",
+        "  sequence. Solr uses Java-based analyzers that originally come from the Apache Lucene project.\n",
+        "- **CustomAnalyzer**: Lucene's builder interface allows fine-grained control over the\n",
+        "  filter and tokenizer pipeline for each supported language. Our pipeline reflects the\n",
+        "  impresso configuration exactly, including language-specific stopwords and stemming\n",
+        "  rules.\n",
+        "- **JPype Integration**: Bridges Python and Java, enabling direct access to Solr's\n",
+        "  analysis pipeline from within Python code.\n",
+        "- **Language Detection**: Optionally uses\n",
+        "  [`LangIdentPipeline`](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/langident)\n",
+        "  to automatically select the language if not specified manually.\n",
+        "- **Post-Processing**: Returns normalized tokens and the language; supports resource cleanup via context manager or destructor.\n"
       ]
     },
     {
@@ -63,7 +105,7 @@
         "In this notebook, you will:\n",
         "\n",
         "- Understand the functionality of the `solrnormalization` subpackage from the Impresso Pipelines package.\n",
-        "- Learn how to normalize a given raw text using language-specific Lucene analyzers.\n",
+        "- Learn how to normalize a raw text using language-specific Solr analyzers.\n",
         "- Explore different use cases, including **basic and advanced usage** of the SolrNormalization pipeline.\n",
         "- Recognize some limitations of the pipeline, such as support for **only selected languages** and the need for JVM integration.\n",
         "\n",
@@ -77,7 +119,8 @@
       },
       "source": [
         "## Useful resources\n",
-        "- For technical details on this library, please refer to the repository of the [Impresso Pipelines package](https://github.com/impresso/impresso-pipelines/tree/main)."
+        "\n",
+        "- For technical details on this library, please refer to the repository of the [Impresso Pipelines package](https://github.com/impresso/impresso-pipelines/tree/main).\n"
       ]
     },
     {
@@ -87,7 +130,8 @@
       },
       "source": [
         "## Prerequisites\n",
-        "First, start by installing the `impresso-pipelines` package. Please note that it might require you to restart the kernel to apply changes. To do so, on Google Colab, go to *Runtime* and select *Restart session*.\n"
+        "\n",
+        "First, start by installing the `impresso-pipelines` package. Please note that it might require you to restart the runtime to apply changes. To do so, on Google Colab, go to _Runtime_ and select _Restart session_.\n"
       ]
     },
     {
@@ -99,7 +143,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install \"impresso_pipelines[solrnormalization]\""
+        "%pip install --upgrade \"impresso-pipelines[solrnormalization]\""
       ]
     },
     {
@@ -110,7 +154,9 @@
       "source": [
         "## Basic Usage\n",
         "\n",
-        "Start by importing the necessary module from the `impresso-pipelines` package.\n"
+        "Import the normalization pipeline from the package and create an instance of the\n",
+        "`SolrNormalization` class. This class provides methods to normalize text in multiple languages using Solr\n",
+        "analyzers.\n"
       ]
     },
     {
@@ -132,24 +178,22 @@
         "id": "9zWWVmCcTqsl"
       },
       "source": [
-        "Once you initialize the pipeline, you can simply provide the text you'd like to normalize. This example demonstrates the use of German text.\n"
+        "Let's take a German example paragraph, which contains special characters and different\n",
+        "punctuation marks.\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "z4yNrxseTMdl"
       },
       "outputs": [],
       "source": [
         "de_text = \"\"\"\n",
-        "\n",
         "In den frühen Morgenstunden verließ der Geschäftsführer der Münchner Rückversicherungsgesellschaft das Gebäude – ein Ereignis,\n",
         "das unter den Mitarbeitenden für großes Aufsehen sorgte. Außerdem wurde über „öffentliche“ Statements spekuliert, obwohl keine\n",
         "offiziellen Informationen verfügbar waren.\n",
-        "\n",
-        "\n",
         "\"\"\""
       ]
     },
@@ -187,7 +231,7 @@
         "id": "7Kxpw368QbD6"
       },
       "source": [
-        "## Advanced Usage"
+        "## Advanced Usage\n"
       ]
     },
     {
@@ -222,7 +266,7 @@
       },
       "outputs": [],
       "source": [
-        "solrnormalization_pipeline(de_text, lang='fr')"
+        "solrnormalization_pipeline(de_text, lang=\"fr\")"
       ]
     },
     {
@@ -243,7 +287,7 @@
         "id": "VDY-g0mDNJIi"
       },
       "source": [
-        "**Example 2**: `diagnostics`"
+        "**Example 2**: `diagnostics`\n"
       ]
     },
     {
@@ -263,7 +307,7 @@
         "id": "cByOAmZMZ9hE"
       },
       "source": [
-        "If you set `diagnostics=True`, the pipeline will also return an additional field, `stopwords_detected` — a list of words from the original text that were identified as stopwords and consequently removed from the final tokenized output."
+        "If you set `diagnostics=True`, the pipeline will also return an additional field, `stopwords_detected` — a list of words from the original text that were identified as stopwords and consequently removed from the final tokenized output.\n"
       ]
     },
     {
@@ -283,7 +327,7 @@
       },
       "outputs": [],
       "source": [
-        "solrnormalization_pipeline(de_text, lang='de', diagnostics=True)"
+        "solrnormalization_pipeline(de_text, lang=\"de\", diagnostics=True)"
       ]
     },
     {
@@ -301,12 +345,12 @@
         "id": "vLlZHIPlWnwE"
       },
       "source": [
-        "**Example 4**: Tokenization of common OCR errors (`^`, `_`, `-`)"
+        "**Example 4**: Tokenization of common OCR errors (`^`, `_`, `-`)\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "id": "59ktEz3hY_9P"
       },
@@ -351,7 +395,7 @@
         "id": "-2Z9qGJWY8Nk"
       },
       "source": [
-        "## Limitations of the Solr Normalization Pipeline"
+        "## Limitations of the Solr Normalization Pipeline\n"
       ]
     },
     {
@@ -395,7 +439,7 @@
         "id": "DM9fXpu4bxRN"
       },
       "source": [
-        "## Conclusion"
+        "## Conclusion\n"
       ]
     },
     {
@@ -406,10 +450,10 @@
       "source": [
         "The `SolrNormalizationPipeline` provides a lightweight, end-to-end solution for applying Solr-style normalization to German and French texts. It delivers:\n",
         "\n",
-        "- **Consistent Preprocessing**: Language-specific analyzers ensure uniform tokenization and normalization aligned with Solr standards.  \n",
-        "- **Easy Integration**: One-line setup and inference with minimal configuration.  \n",
-        "- **Optional Language Control**: Users can rely on built-in language detection or manually specify the language.  \n",
-        "- **Transparent Output**: Returns clean token lists that reveal exactly how input text is normalized.  \n",
+        "- **Consistent Preprocessing**: Language-specific analyzers ensure uniform tokenization and normalization aligned with Solr standards.\n",
+        "- **Easy Integration**: One-line setup and inference with minimal configuration.\n",
+        "- **Optional Language Control**: Users can rely on built-in language detection or manually specify the language.\n",
+        "- **Transparent Output**: Returns clean token lists that reveal exactly how input text is normalized.\n",
         "- **Future Extensibility**: Designed to be extended with more languages, diagnostics, and custom analyzer configurations.\n",
         "\n",
         "Whether you're preparing data for indexing, building reproducible NLP pipelines, or analyzing German and French corpora, this pipeline simplifies language-aware normalization—without requiring deep Lucene or Java expertise.\n"
@@ -421,7 +465,7 @@
         "id": "AL4iHEtob3KD"
       },
       "source": [
-        "## Next steps"
+        "## Next steps\n"
       ]
     },
     {
@@ -430,7 +474,7 @@
         "id": "MyxXhuPAb541"
       },
       "source": [
-        "To get a better understanding of how this pipeline works, please check out the [original repository](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization)."
+        "To get a better understanding of how this pipeline works, please check out the [original repository](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization).\n"
       ]
     },
     {
@@ -473,11 +517,21 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": ".venv",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.7"
     }
   },
   "nbformat": 4,

--- a/annotate/solrnormalization_pipeline_demo.ipynb
+++ b/annotate/solrnormalization_pipeline_demo.ipynb
@@ -1,0 +1,386 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QFaBppP2Sb6z"
+      },
+      "source": [
+        "# Solr Normalization with impresso-pipelines Package\n",
+        "\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/impresso/impresso-datalab-notebooks/blob/main/annotate/solrnormalization_pipeline_demo.ipynb\">\n",
+        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "</a>\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nAcbQs-NSwsL"
+      },
+      "source": [
+        "## What is this notebook about?\n",
+        "This notebook introduces the SolrNormalization component of the [impresso-pipelines](https://pypi.org/project/impresso-pipelines/) Python package. The broader goal of the impresso pipelines is to make the internal data processing workflows of the impresso project reusable and accessible to others. It allows external users—such as researchers, developers, or digital humanities practitioners—to apply the same processing steps we used on our historical newspaper collections to their own text collections.\n",
+        "\n",
+        "The package is designed to minimize the coding effort required. By offering ready-to-use pipelines, users can adopt impresso approach to document processing with minimal configuration. This ensures consistency, comparability, and transparency in how Solr-normalized data is prepared and evaluated.\n",
+        "\n",
+        "In this notebook, we focus on the [solrnormalization](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization) subpackage, which enables Solr-style tokenization and normalization using Lucene analyzers directly from Python. It supports language detection and applies language-specific analyzers for German and French.\n",
+        "\n",
+        "\n",
+        "## Why is this useful?\n",
+        "\n",
+        "*   Text collections—especially historical or multilingual ones—often contain inconsistencies in spelling, formatting, and linguistic conventions across languages, time periods, and sources.\n",
+        "*   This pipeline provides a standardized, language-aware normalization process using Lucene analyzers, making it easier to apply consistent preprocessing across supported languages and prepare clean, comparable input for downstream models or analytical tools.\n",
+        "*   It also makes the normalization process more transparent by exposing the exact tokens produced after language-specific analyzers are applied.\n",
+        "\n",
+        "\n",
+        "## How it works\n",
+        "\n",
+        "*   **Init**: Load Lucene analyzers and stopword lists for supported languages (`de`, `fr`).\n",
+        "*   **Language Detection**: Automatically detect the language of the input text unless manually specified.\n",
+        "*   **Analyze**: Apply language-specific tokenization, lowercasing, stopword removal, ASCII folding, and stemming using Lucene filters.\n",
+        "*   **Output**: Return a list of normalized tokens along with the detected language.\n",
+        "*   **Extras**: Optionally pass a custom Lucene JAR directory or enable `__enter__/__exit__` context handling for cleanup.\n",
+        "\n",
+        "\n",
+        "## Technical background\n",
+        "\n",
+        "- **Lucene Analyzers**: Java-based components that apply tokenization, lowercasing, stopword removal, ASCII folding, and light language-specific normalization in a configurable sequence.\n",
+        "- **CustomAnalyzer**: Lucene's builder interface allows fine-grained control over the filter and tokenizer pipeline for each supported language.\n",
+        "- **JPype Integration**: Bridges Python and Java, enabling direct access to Lucene's analysis pipeline from within Python code.\n",
+        "- **Language Detection**: Uses [`LangIdentPipeline`](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/langident) to automatically select the appropriate analyzer when the language is not specified manually.\n",
+        "- **Post-Processing**: Returns normalized tokens and the detected language; supports resource cleanup via context manager or destructor.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MvRaGa7jS0Zg"
+      },
+      "source": [
+        "## What will you learn?\n",
+        "\n",
+        "In this notebook, you will:\n",
+        "\n",
+        "- Understand the functionality of the `solrnormalization` subpackage from the Impresso Pipelines package.\n",
+        "- Learn how to normalize a given raw text using language-specific Lucene analyzers.\n",
+        "- Explore different use cases, including **basic and advanced usage** of the SolrNormalization pipeline.\n",
+        "- Recognize some limitations of the pipeline, such as support for **only selected languages** and the need for JVM integration.\n",
+        "\n",
+        "By the end of this notebook, you will have a clear understanding of how Solr-style normalization is applied to text and how it can be used in practical scenarios.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_Ek_DUzRS5wR"
+      },
+      "source": [
+        "## Useful resources\n",
+        "- For technical details on this library, please refer to the repository of the [Impresso Pipelines package](https://github.com/impresso/impresso-pipelines/tree/main)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PBdL2WC0S-vh"
+      },
+      "source": [
+        "## Prerequisites\n",
+        "First, start by installing `impresso-pipelines` package. Please, note that it might require you to restart kernel to apply changes. To do so, on Google Colab, go to *Runtime* and select *Restart session*.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Jc2KhsawQ8bv",
+        "collapsed": true
+      },
+      "outputs": [],
+      "source": [
+        "%pip install \"impresso_pipelines[solrnormalization]\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vW6_QLg_THhc"
+      },
+      "source": [
+        "## Basic Usage\n",
+        "\n",
+        "Start by importing the necessary module from `impresso-pipelines` package\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "N1kYDZMOTHqI"
+      },
+      "outputs": [],
+      "source": [
+        "from impresso_pipelines.solrnormalization import SolrNormalizationPipeline\n",
+        "\n",
+        "solrnormalization_pipeline = SolrNormalizationPipeline()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9zWWVmCcTqsl"
+      },
+      "source": [
+        "Once you initialize the pipeline, you can simply provide the text you'd like to extract news agencies for. This example demonstrates the use of German text.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "z4yNrxseTMdl"
+      },
+      "outputs": [],
+      "source": [
+        "de_text = \"\"\"\n",
+        "\n",
+        "In den frühen Morgenstunden verließ der Geschäftsführer der Münchner Rückversicherungsgesellschaft das Gebäude – ein Ereignis,\n",
+        "das unter den Mitarbeitenden für großes Aufsehen sorgte. Außerdem wurde über „öffentliche“ Statements spekuliert, obwohl keine\n",
+        "offiziellen Informationen verfügbar waren.\n",
+        "\n",
+        "\n",
+        "\"\"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "n_JPtOlIVQCU"
+      },
+      "outputs": [],
+      "source": [
+        "solrnormalization_pipeline(de_text)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CLbfwYjMMOrD"
+      },
+      "source": [
+        "**Interpretation of the result:**\n",
+        "\n",
+        "As can be seen, the returned result is a dictionary with two keys: `\"language\"` and `\"tokens\"`.\n",
+        "\n",
+        "- `language` indicates the language detected for the input text (in this case, `'de'` for German). If a language is manually specified, it will override the detection.\n",
+        "\n",
+        "- `tokens` is a list of normalized tokens extracted from the text using a Lucene analyzer. These tokens are lowercased, stripped of stopwords, and normalized to remove accents and standardize common linguistic variants.\n",
+        "\n",
+        "The output shows how long compound words (e.g., `Rückversicherungsgesellschaft`), special characters (e.g., `ü` in `früh`), and punctuation (e.g., quotes and dashes) are handled and broken down into analyzable components.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7Kxpw368QbD6"
+      },
+      "source": [
+        "## Advanced Usage"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "COx0hlwmQmWT"
+      },
+      "source": [
+        "This pipeline currently supports a single optional attribute when calling it, allowing limited control over its behavior while keeping usage simple and reproducible.\n",
+        "\n",
+        "- `lang`: expects a string language code (e.g., `'de'` or `'fr'`). If provided, the pipeline skips automatic language detection and directly applies the corresponding Lucene analyzer. This can improve performance slightly and is useful in controlled multilingual settings.\n",
+        "\n",
+        "Additional configuration options (e.g., customizing stopword lists, overriding analyzers, or enabling diagnostics) are not yet exposed but could be added in future versions to support more advanced use cases and deeper inspection of the normalization process.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ManNU1dtSXbl"
+      },
+      "source": [
+        "**Example 1:** `lang`\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "i5h95lR-LFUw"
+      },
+      "outputs": [],
+      "source": [
+        "solrnormalization_pipeline(de_text, lang='fr')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I17tyTgTSiI1"
+      },
+      "source": [
+        "If you specify `lang='fr'`, the pipeline will skip automatic language detection and apply the French analyzer directly—even if the input text is in another language.  \n",
+        "This can be useful in controlled setups where you already know the correct language, or when comparing how the same text is normalized under different analyzers.\n",
+        "\n",
+        "In this example, we manually forced the pipeline to use the French analyzer on a German text. As a result, many German stopwords remain in the output, and language-specific filters (like German normalization or minimal stemming) are not applied.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-2Z9qGJWY8Nk"
+      },
+      "source": [
+        "## Limitations of the Solr Normalization Pipeline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "KYX9q5SDY-oP"
+      },
+      "outputs": [],
+      "source": [
+        "unsupported_languages = \"\"\"In the early hours of the morning, the CEO of the Munich reinsurance company left the building – an event\n",
+        " that caused a great stir among the employees. Additionally, there was speculation about “public” statements, although no\n",
+        " official information was available.\"\"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3BYnm_iXZjHM"
+      },
+      "outputs": [],
+      "source": [
+        "solrnormalization_pipeline(unsupported_languages)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BO5HLC54aSAS"
+      },
+      "source": [
+        "As shown, the Solr Normalization Pipeline currently supports only two languages: German (`'de'`) and French (`'fr'`). If the input text is in another language, such as English, and no `lang` argument is specified, the pipeline will attempt to detect the language automatically and raise an error if it's not supported.\n",
+        "\n",
+        "In this case, the detected language was `'en'`, which caused the pipeline to raise a `ValueError`. This behavior is intentional to ensure that unsupported languages are not processed with incorrect analyzers, which could lead to misleading results.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DM9fXpu4bxRN"
+      },
+      "source": [
+        "## Conclusion"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9101-ciSb0yg"
+      },
+      "source": [
+        "The `SolrNormalizationPipeline` provides a lightweight, end-to-end solution for applying Solr-style normalization to German and French texts. It delivers:\n",
+        "\n",
+        "- **Consistent Preprocessing**: Language-specific analyzers ensure uniform tokenization and normalization aligned with Solr standards.  \n",
+        "- **Easy Integration**: One-line setup and inference with minimal configuration.  \n",
+        "- **Optional Language Control**: Users can rely on built-in language detection or manually specify the language.  \n",
+        "- **Transparent Output**: Returns clean token lists that reveal exactly how input text is normalized.  \n",
+        "- **Future Extensibility**: Designed to be extended with more languages, diagnostics, and custom analyzer configurations.\n",
+        "\n",
+        "Whether you're preparing data for indexing, building reproducible NLP pipelines, or analyzing German and French corpora, this pipeline simplifies language-aware normalization—without requiring deep Lucene or Java expertise.\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AL4iHEtob3KD"
+      },
+      "source": [
+        "## Next steps"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MyxXhuPAb541"
+      },
+      "source": [
+        "To get more understanding of how this pipeline works, please check out the [original repository](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "B2C0NVdVb-sR"
+      },
+      "source": [
+        "---\n",
+        "## Project and License info\n",
+        "\n",
+        "### Notebook credits [![CreditLogo.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAARCAYAAAGnXcxvAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAJYAAAABAAAAlgAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEqADAAQAAAABAAAAEQAAAACvX75vAAAACXBIWXMAABcSAAAXEgFnn9JSAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoZXuEHAAAD/UlEQVQ4ES1UW2hcVRRd+9w7907mkUfTmEczkzRpraH1gUWaZBKJ0BY/FKsSwS9BClbxv1V/RlAC/vghghShBVuVRo2GQv1Qa0xSalAi2sxMJNF2Yt7oJDOZmZs795zjvtMe5s7A2Xevvddaew/A51asz00CAun2Xp2bmNbpfb3aDyDFF/4vzR0eilBeHqc/AB15423/Ztii/NpzNNs5VB/c2M55pVn/VQTa+/4yy54t7JIDo/4otGQMIrMaTccSF1Oxfobhs9B8TN9CRKcfOa7nYJTE7vomJHZgn+yHB1lD89xJZXkNxN1RR3MFSe4zHU+Mp2N9Sz4EXcGw8XB87eWoVudz0iuR1DWwREW7SghDmD0rN8l8MLZ808vmHzW/GkH4l99C0aEEcqNfWw3Dp1C4MYM7l20tfDgGrH6s2D7kv59AeKAPheuTKCTPAU4FxFREpiPxmi3VBw50hTMC0FpxnhcSptWZnSZ+KSkISZWJJ15Q0EmtdZdB9Ilh1b1+YOGayzU0P8BiPKEdx63AMkBSmVpQuVEbof8s48We2y2jlIn1b6qGYNT7/QfbbD0GtfozVzrAqQsIdw+iGGyxhRUQe6k2ZLeOXUXo9NPY+9kXCAwPou2naRQX16XIr3wjdknr1pG3sPrsUzD21MOsjaI8egGluQzEQ+1Ca/m4sDXR6tl30Hb1W0ABW+PXfEGgHRdwpSISk35PORUyI2p+xiTrAVBzEDANYKkIq6UGOlgfrLL7Jz6g87Li0zUZmB1EJQwRKJJ4qSfbetlXnNqzUxyyXtFCbPiVBInxC0snjZ7s1CXCqPQVJ0aozuGf+xMnlNQjURJHLYYrKYmy3yhHQ1ygRhhwtEYResqDOHckOznt5zPw3a9UbPBUrcBYcdeFrLOLVBcKUZG1KTHBxrBPEnqjAIraYEmVIpRtpxKmnIPdgHii5/bUjyIV7z/boPVYPkiOXFuGml8MW48dIXGwHervAsyDcYhYE+TaDPNrhOhuE2a8OaS62+BsO049ieupjsHTlGrvK4uoFaykJ9D0+ZeAlNj6+FPI67PYc+k9qJ0deP/mUJvoxZ2hATSdvwir+T6sP3MG4lCnNssV8jRWqqNbFcjnabAVzFjOZlmWErTrIti1H7WD/dh4/yNeJLZ2hxXie40se8M390QiXs8360Dvbtlw9cKyhUgDrOd57rYKkL8uAGELen4TxtAhqMwKELHuJvNuKEFuA5nWNvSZquKZ+MBwHdGVnOcqTpREFIDkhVBczn/YKVj8v1B0QbwB7L2LXc+KGgF2FSfuz059V7X/nn060znwJAN8WEeii31Cmfeu4oPwCfCQ1JBRpVfQas5D4NXDSxOTHK2Oz/88172PBBmtMAAAAABJRU5ErkJggg==)](https://credit.niso.org/)\n",
+        "\n",
+        "INSERT CREDITS HERE\n",
+        "<br></br>\n",
+        "This notebook is published under [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)\n",
+        "<br><a target=\"_blank\" href=\"https://creativecommons.org/licenses/by/4.0/\">\n",
+        "  <img src=\"https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by.png\"  width=\"100\" alt=\"Open In Colab\"/>\n",
+        "</a>\n",
+        "<br></br>\n",
+        "\n",
+        "### Impresso project\n",
+        "\n",
+        "[Impresso - Media Monitoring of the Past](https://impresso-project.ch) is an interdisciplinary research project that aims to develop and consolidate tools for processing and exploring large collections of media archives across modalities, time, languages and national borders. The first project (2017-2021) was funded by the Swiss National Science Foundation under grant No. [CRSII5_173719](http://p3.snf.ch/project-173719) and the second project (2023-2027) by the SNSF under grant No. [CRSII5_213585](https://data.snf.ch/grants/grant/213585) and the Luxembourg National Research Fund under grant No. 17498891.\n",
+        "<br></br>\n",
+        "### License\n",
+        "\n",
+        "All Impresso code is published open source under the [GNU Affero General Public License](https://github.com/impresso/impresso-pyindexation/blob/master/LICENSE) v3 or later.\n",
+        "\n",
+        "\n",
+        "---\n",
+        "\n",
+        "<p align=\"center\">\n",
+        "  <img src=\"https://github.com/impresso/impresso.github.io/blob/master/assets/images/3x1--Yellow-Impresso-Black-on-White--transparent.png?raw=true\" width=\"350\" alt=\"Impresso Project Logo\"/>\n",
+        "</p>\n",
+        "\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/annotate/solrnormalization_pipeline_demo.ipynb
+++ b/annotate/solrnormalization_pipeline_demo.ipynb
@@ -22,7 +22,7 @@
         "## What is this notebook about?\n",
         "This notebook introduces the SolrNormalization component of the [impresso-pipelines](https://pypi.org/project/impresso-pipelines/) Python package. The broader goal of the impresso pipelines is to make the internal data processing workflows of the impresso project reusable and accessible to others. It allows external users—such as researchers, developers, or digital humanities practitioners—to apply the same processing steps we used on our historical newspaper collections to their own text collections.\n",
         "\n",
-        "The package is designed to minimize the coding effort required. By offering ready-to-use pipelines, users can adopt impresso approach to document processing with minimal configuration. This ensures consistency, comparability, and transparency in how Solr-normalized data is prepared and evaluated.\n",
+        "The package is designed to minimize the coding effort required. By offering ready-to-use pipelines, users can adopt the impresso approach to document processing with minimal configuration. This ensures consistency, comparability, and transparency in how Solr-normalized data is prepared and evaluated.\n",
         "\n",
         "In this notebook, we focus on the [solrnormalization](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization) subpackage, which enables Solr-style tokenization and normalization using Lucene analyzers directly from Python. It supports language detection and applies language-specific analyzers for German and French.\n",
         "\n",
@@ -49,8 +49,7 @@
         "- **CustomAnalyzer**: Lucene's builder interface allows fine-grained control over the filter and tokenizer pipeline for each supported language.\n",
         "- **JPype Integration**: Bridges Python and Java, enabling direct access to Lucene's analysis pipeline from within Python code.\n",
         "- **Language Detection**: Uses [`LangIdentPipeline`](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/langident) to automatically select the appropriate analyzer when the language is not specified manually.\n",
-        "- **Post-Processing**: Returns normalized tokens and the detected language; supports resource cleanup via context manager or destructor.\n",
-        "\n"
+        "- **Post-Processing**: Returns normalized tokens and the detected language; supports resource cleanup via context manager or destructor.\n"
       ]
     },
     {
@@ -68,8 +67,7 @@
         "- Explore different use cases, including **basic and advanced usage** of the SolrNormalization pipeline.\n",
         "- Recognize some limitations of the pipeline, such as support for **only selected languages** and the need for JVM integration.\n",
         "\n",
-        "By the end of this notebook, you will have a clear understanding of how Solr-style normalization is applied to text and how it can be used in practical scenarios.\n",
-        "\n"
+        "By the end of this notebook, you will have a clear understanding of how Solr-style normalization is applied to text and how it can be used in practical scenarios.\n"
       ]
     },
     {
@@ -89,8 +87,7 @@
       },
       "source": [
         "## Prerequisites\n",
-        "First, start by installing `impresso-pipelines` package. Please, note that it might require you to restart kernel to apply changes. To do so, on Google Colab, go to *Runtime* and select *Restart session*.\n",
-        "\n"
+        "First, start by installing the `impresso-pipelines` package. Please note that it might require you to restart the kernel to apply changes. To do so, on Google Colab, go to *Runtime* and select *Restart session*.\n"
       ]
     },
     {
@@ -113,7 +110,7 @@
       "source": [
         "## Basic Usage\n",
         "\n",
-        "Start by importing the necessary module from `impresso-pipelines` package\n"
+        "Start by importing the necessary module from the `impresso-pipelines` package.\n"
       ]
     },
     {
@@ -181,8 +178,7 @@
         "\n",
         "- `tokens` is a list of normalized tokens extracted from the text using a Lucene analyzer. These tokens are lowercased, stripped of stopwords, and normalized to remove accents and standardize common linguistic variants.\n",
         "\n",
-        "The output shows how long compound words (e.g., `Rückversicherungsgesellschaft`), special characters (e.g., `ü` in `früh`), and punctuation (e.g., quotes and dashes) are handled and broken down into analyzable components.\n",
-        "\n"
+        "The output shows how long compound words (e.g., `Rückversicherungsgesellschaft`), special characters (e.g., `ü` in `früh`), and punctuation (e.g., quotes and dashes) are handled and broken down into analyzable components.\n"
       ]
     },
     {
@@ -200,11 +196,11 @@
         "id": "COx0hlwmQmWT"
       },
       "source": [
-        "This pipeline currently supports a single optional attribute when calling it, allowing limited control over its behavior while keeping usage simple and reproducible.\n",
+        "This pipeline currently supports two optional attributes when calling it, allowing limited control over its behavior while keeping usage simple and reproducible.\n",
         "\n",
         "- `lang`: expects a string language code (e.g., `'de'` or `'fr'`). If provided, the pipeline skips automatic language detection and directly applies the corresponding Lucene analyzer. This can improve performance slightly and is useful in controlled multilingual settings.\n",
         "\n",
-        "- `diagnostics`: expects a Boolean value. If set to `True`, pipeline will return additional information such as removed stopwords from the provided text.\n",
+        "- `diagnostics`: expects a Boolean value. If set to `True`, the pipeline will return additional information such as removed stopwords from the provided text.\n",
         "\n",
         "These attributes can be used individually, in combination with each other, or all at once, depending on the level of detail needed.\n"
       ]
@@ -215,9 +211,7 @@
         "id": "ManNU1dtSXbl"
       },
       "source": [
-        "**Example 1:** `lang`\n",
-        "\n",
-        "\n"
+        "**Example 1:** `lang`\n"
       ]
     },
     {
@@ -245,73 +239,78 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "**Example 2**: `diagnostics`"
-      ],
       "metadata": {
         "id": "VDY-g0mDNJIi"
-      }
+      },
+      "source": [
+        "**Example 2**: `diagnostics`"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "solrnormalization_pipeline(de_text, diagnostics=True)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "soDoUptZNWpQ"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "solrnormalization_pipeline(de_text, diagnostics=True)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "If you set `diagnostics=True`, the pipeline will also return an additional field, `stopwords_detected` — a list of words from the original text that were identified as stopwords and consequently removed from the final tokenized output."
-      ],
       "metadata": {
         "id": "cByOAmZMZ9hE"
-      }
+      },
+      "source": [
+        "If you set `diagnostics=True`, the pipeline will also return an additional field, `stopwords_detected` — a list of words from the original text that were identified as stopwords and consequently removed from the final tokenized output."
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "**Example 3**: All at once\n"
-      ],
       "metadata": {
         "id": "-NFhSDjRVTfX"
-      }
+      },
+      "source": [
+        "**Example 3**: All at once\n"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "solrnormalization_pipeline(de_text, lang='de', diagnostics=True)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "GaHJhQ8_VUpo"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "solrnormalization_pipeline(de_text, lang='de', diagnostics=True)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can combine multiple options in a single call, like specifying the language and enabling diagnostics. The pipeline is flexible and allows using any combination of supported parameters.\n"
-      ],
       "metadata": {
         "id": "P_aZm8lCcuMo"
-      }
+      },
+      "source": [
+        "You can combine multiple options in a single call, like specifying the language and enabling diagnostics. The pipeline is flexible and allows using any combination of supported parameters.\n"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "**Example 4**: Tokenization of common OCR erros (`^`, `_`, `-`)"
-      ],
       "metadata": {
         "id": "vLlZHIPlWnwE"
-      }
+      },
+      "source": [
+        "**Example 4**: Tokenization of common OCR errors (`^`, `_`, `-`)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "59ktEz3hY_9P"
+      },
+      "outputs": [],
       "source": [
         "altered_de_text = \"\"\"\n",
         "\n",
@@ -321,36 +320,30 @@
         "\n",
         "\n",
         "\"\"\""
-      ],
-      "metadata": {
-        "id": "59ktEz3hY_9P"
-      },
-      "execution_count": 9,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "solrnormalization_pipeline(altered_de_text, diagnostics=True)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "rUkAkdwzZThd"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "solrnormalization_pipeline(altered_de_text, diagnostics=True)"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "JuXxeBAFY-E9"
+      },
       "source": [
         "This example illustrates how common OCR-related artifacts such as `^`, `_`, and hyphens are handled during normalization and tokenization.\n",
         "These characters often appear in digitized historical documents due to misrecognition or formatting inconsistencies.\n",
         "\n",
-        "As can be seen above, `^` and `-` forces word to be split, resulting in two different tokenized words. `_` on the other hand is just treated as part of the word.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "JuXxeBAFY-E9"
-      }
+        "As can be seen above, `^` and `-` force words to be split, resulting in two different tokenized words. `_` on the other hand is just treated as part of the word.\n"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -419,9 +412,7 @@
         "- **Transparent Output**: Returns clean token lists that reveal exactly how input text is normalized.  \n",
         "- **Future Extensibility**: Designed to be extended with more languages, diagnostics, and custom analyzer configurations.\n",
         "\n",
-        "Whether you're preparing data for indexing, building reproducible NLP pipelines, or analyzing German and French corpora, this pipeline simplifies language-aware normalization—without requiring deep Lucene or Java expertise.\n",
-        "\n",
-        "\n"
+        "Whether you're preparing data for indexing, building reproducible NLP pipelines, or analyzing German and French corpora, this pipeline simplifies language-aware normalization—without requiring deep Lucene or Java expertise.\n"
       ]
     },
     {
@@ -439,7 +430,7 @@
         "id": "MyxXhuPAb541"
       },
       "source": [
-        "To get more understanding of how this pipeline works, please check out the [original repository](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization)."
+        "To get a better understanding of how this pipeline works, please check out the [original repository](https://github.com/impresso/impresso-pipelines/tree/main/impresso_pipelines/solrnormalization)."
       ]
     },
     {
@@ -469,13 +460,11 @@
         "\n",
         "All Impresso code is published open source under the [GNU Affero General Public License](https://github.com/impresso/impresso-pyindexation/blob/master/LICENSE) v3 or later.\n",
         "\n",
-        "\n",
         "---\n",
         "\n",
         "<p align=\"center\">\n",
         "  <img src=\"https://github.com/impresso/impresso.github.io/blob/master/assets/images/3x1--Yellow-Impresso-Black-on-White--transparent.png?raw=true\" width=\"350\" alt=\"Impresso Project Logo\"/>\n",
-        "</p>\n",
-        "\n"
+        "</p>\n"
       ]
     }
   ],

--- a/annotate/solrnormalization_pipeline_demo.ipynb
+++ b/annotate/solrnormalization_pipeline_demo.ipynb
@@ -140,7 +140,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 2,
       "metadata": {
         "id": "z4yNrxseTMdl"
       },
@@ -204,8 +204,9 @@
         "\n",
         "- `lang`: expects a string language code (e.g., `'de'` or `'fr'`). If provided, the pipeline skips automatic language detection and directly applies the corresponding Lucene analyzer. This can improve performance slightly and is useful in controlled multilingual settings.\n",
         "\n",
-        "Additional configuration options (e.g., customizing stopword lists, overriding analyzers, or enabling diagnostics) are not yet exposed but could be added in future versions to support more advanced use cases and deeper inspection of the normalization process.\n",
-        "\n"
+        "- `diagnostics`: expects a Boolean value. If set to `True`, pipeline will return additional information such as removed stopwords from the provided text.\n",
+        "\n",
+        "These attributes can be used individually, in combination with each other, or all at once, depending on the level of detail needed.\n"
       ]
     },
     {
@@ -244,6 +245,115 @@
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "**Example 2**: `diagnostics`"
+      ],
+      "metadata": {
+        "id": "VDY-g0mDNJIi"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "solrnormalization_pipeline(de_text, diagnostics=True)"
+      ],
+      "metadata": {
+        "id": "soDoUptZNWpQ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If you set `diagnostics=True`, the pipeline will also return an additional field, `stopwords_detected` — a list of words from the original text that were identified as stopwords and consequently removed from the final tokenized output."
+      ],
+      "metadata": {
+        "id": "cByOAmZMZ9hE"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Example 3**: All at once\n"
+      ],
+      "metadata": {
+        "id": "-NFhSDjRVTfX"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "solrnormalization_pipeline(de_text, lang='de', diagnostics=True)"
+      ],
+      "metadata": {
+        "id": "GaHJhQ8_VUpo"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "You can combine multiple options in a single call, like specifying the language and enabling diagnostics. The pipeline is flexible and allows using any combination of supported parameters.\n"
+      ],
+      "metadata": {
+        "id": "P_aZm8lCcuMo"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Example 4**: Tokenization of common OCR erros (`^`, `_`, `-`)"
+      ],
+      "metadata": {
+        "id": "vLlZHIPlWnwE"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "altered_de_text = \"\"\"\n",
+        "\n",
+        "In den frühen Morge^stunden verließ der Geschäftsführer der Münchner Rückversicherungsgesellschaft das Gebäude – ein Ereignis,\n",
+        "das unter den Mitar_eitenden für großes Aufsehen sorgte. Außerdem wurde über „öffentliche“ Statements spekuliert, obwohl keine\n",
+        "offiziellen Inform-tionen verfügbar waren.\n",
+        "\n",
+        "\n",
+        "\"\"\""
+      ],
+      "metadata": {
+        "id": "59ktEz3hY_9P"
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "solrnormalization_pipeline(altered_de_text, diagnostics=True)"
+      ],
+      "metadata": {
+        "id": "rUkAkdwzZThd"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This example illustrates how common OCR-related artifacts such as `^`, `_`, and hyphens are handled during normalization and tokenization.\n",
+        "These characters often appear in digitized historical documents due to misrecognition or formatting inconsistencies.\n",
+        "\n",
+        "As can be seen above, `^` and `-` forces word to be split, resulting in two different tokenized words. `_` on the other hand is just treated as part of the word.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "JuXxeBAFY-E9"
+      }
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "-2Z9qGJWY8Nk"
       },
@@ -253,7 +363,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "id": "KYX9q5SDY-oP"
       },

--- a/annotate/solrnormalization_pipeline_demo.ipynb
+++ b/annotate/solrnormalization_pipeline_demo.ipynb
@@ -97,8 +97,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Jc2KhsawQ8bv",
-        "collapsed": true
+        "collapsed": true,
+        "id": "Jc2KhsawQ8bv"
       },
       "outputs": [],
       "source": [
@@ -135,7 +135,7 @@
         "id": "9zWWVmCcTqsl"
       },
       "source": [
-        "Once you initialize the pipeline, you can simply provide the text you'd like to extract news agencies for. This example demonstrates the use of German text.\n"
+        "Once you initialize the pipeline, you can simply provide the text you'd like to normalize. This example demonstrates the use of German text.\n"
       ]
     },
     {


### PR DESCRIPTION
**Added a new demo notebook showcasing the usage of the `impresso` pipeline `solrnormalization`**

This notebook demonstrates how to normalize and process text using the `solrnormalization` pipeline, replicating Solr’s behavior.  
I’d appreciate any feedback or suggestions for improvement!
